### PR TITLE
Include FxUX banner from GitHub Pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/report.css">
   <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-  <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+  <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
   <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
 </head>
 <body>

--- a/asia_task_continuity.html
+++ b/asia_task_continuity.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/report.css">
   <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-  <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+  <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
   <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 
- <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>  <!doctype html>
+ <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>  <!doctype html>
   <html class="no-js" lang="">
   <head>
     <meta charset="utf-8">
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/main.css">
     <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-    <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+    <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
     <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
   </head>
   <body>

--- a/report_template.html
+++ b/report_template.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/report.css">
   <script src="js/vendor/modernizr-2.8.3.min.js"></script>
-  <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+  <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
   <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
 </head>
 <body>


### PR DESCRIPTION
This was broken because raw.githubusercontent.com serves things with `text/plain`, which caused browsers to ignore them.